### PR TITLE
fix: Remove unnecessary binary deps and upgrade node

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,6 +1,3 @@
 git
 tar
-python3-dnf
-python3-pip
-curl-minimal
 jq


### PR DESCRIPTION
Removes binary dependencies that aren't necessary. `ansible.builtin.package` should use the appropriate package manager in the base image, and we do not need `python3-pip` for uv.

Working on adding node changes.